### PR TITLE
Add caching and normalization for FAISS index

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import os
 import json
 import argparse
-import numpy as np
 from tqdm import tqdm
 from collections import defaultdict
 import torch
@@ -20,7 +19,7 @@ from functools import partial
 
 from utils.reader import PDFReader, MarkdownReader
 from utils.eval import load_json, evaluate_average_precision_at_1, calculate_category_wise_ap
-from utils.retriever import HybridRAGRetriever
+from utils.retriever import FAISSRetriever
 
 
 
@@ -35,10 +34,14 @@ class RetrieverPipeline:
         self.pdf_reader = PDFReader()
         self.markdown_reader = MarkdownReader()
         self.use_markdown = use_markdown  # 控制是否使用Markdown格式
+        self.index_dir = os.path.join(self.source_path, 'faiss_indexes')
+        os.makedirs(self.index_dir, exist_ok=True)
         self.retrievers = {
-            'finance': HybridRAGRetriever(embed_model='altaidevorg/bge-m3-distill-8l'),
-            'insurance': HybridRAGRetriever(embed_model='altaidevorg/bge-m3-distill-8l'),
-            'faq': HybridRAGRetriever(embed_model='altaidevorg/bge-m3-distill-8l')
+            'finance': FAISSRetriever(embed_model='altaidevorg/bge-m3-distill-8l',
+                                     index_path=os.path.join(self.index_dir, 'finance.index')),
+            'insurance': FAISSRetriever(embed_model='altaidevorg/bge-m3-distill-8l',
+                                       index_path=os.path.join(self.index_dir, 'insurance.index')),
+            'faq': FAISSRetriever(embed_model='altaidevorg/bge-m3-distill-8l')
         }
     
     def load_pid_map(self):
@@ -109,11 +112,17 @@ class RetrieverPipeline:
         qs_ref = load_json(self.question_path)
         key_to_source_dict = self.load_pid_map()
 
-        # 載入不同類別的corpus
+        # 載入不同類別的corpus並建立索引
         corpus = {}
         for category in ['finance', 'insurance']:
             source_ids = self.get_unique_source_ids(qs_ref, category)
             corpus[category] = self.load_corpus(category, source_ids)
+            index_file = self.retrievers[category].index_path
+            if index_file and os.path.exists(index_file):
+                self.retrievers[category].load_index(index_file)
+            else:
+                documents = [corpus[category][doc_id] for doc_id in source_ids]
+                self.retrievers[category].build_index(documents, source_ids, save_path=index_file)
         
         # 處理每個問題
         for q_dict in tqdm(qs_ref['questions'], desc='Processing questions'):
@@ -122,6 +131,8 @@ class RetrieverPipeline:
             if retriever:
                 if category == 'faq':
                     corpus_faq = {key: str(value) for key, value in key_to_source_dict.items() if key in q_dict['source']}
+                    documents = [corpus_faq[doc_id] for doc_id in q_dict['source']]
+                    retriever.build_index(documents, q_dict['source'])
                     retrieved = retriever.retrieve(q_dict['query'], q_dict['source'], corpus_faq)
                 else:
                     retrieved = retriever.retrieve(q_dict['query'], q_dict['source'], corpus[category])

--- a/utils/retriever.py
+++ b/utils/retriever.py
@@ -5,6 +5,9 @@ from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer, AutoModelForCausalLM, AutoModelForSequenceClassification
 from langchain.text_splitter import CharacterTextSplitter
 from collections import defaultdict
+import os
+import numpy as np
+import faiss
 
 
 # embedding_model = 
@@ -393,3 +396,64 @@ class BGERetrieverWithRerank(Retriever):
             best_idx = rerank_scores.argmax().item()
             best_source = top_k_sources[best_idx]
             return best_source
+
+
+class FAISSRetriever(Retriever):
+    """FAISS-based embedding retriever with optional on-disk caching."""
+
+    def __init__(self, embed_model='altaidevorg/bge-m3-distill-8l', device='cuda', index_path=None):
+        self.device = torch.device(device)
+        if embed_model == 'BAAI/bge-m3':
+            model_path = 'model/BAAI__bge-m3'
+        elif embed_model == 'altaidevorg/bge-m3-distill-8l':
+            model_path = 'model/altaidevorg__bge-m3-distill-8l'
+        else:
+            model_path = embed_model
+        self.embed_model = SentenceTransformer(model_path, device=device)
+        self.index = None
+        self.doc_ids = None
+        self.dimension = 1024
+        self.index_path = index_path
+
+    def load_index(self, index_file):
+        self.index = faiss.read_index(index_file)
+        ids_path = index_file + '_ids.npy'
+        if os.path.exists(ids_path):
+            self.doc_ids = np.load(ids_path).tolist()
+
+    def save_index(self, index_file):
+        faiss.write_index(self.index, index_file)
+        np.save(index_file + '_ids.npy', np.array(self.doc_ids))
+
+    def build_index(self, documents, doc_ids, save_path=None):
+        embeddings = self.embed_model.encode(
+            documents,
+            convert_to_tensor=True,
+            show_progress_bar=False,
+            batch_size=32,
+            normalize_embeddings=True,
+        )
+        embeddings = embeddings.cpu().numpy().astype('float32')
+        faiss.normalize_L2(embeddings)
+        self.index = faiss.IndexHNSWFlat(self.dimension, 32)
+        self.index.hnsw.efConstruction = 200
+        self.index.add(embeddings)
+        self.doc_ids = list(doc_ids)
+        if save_path:
+            self.save_index(save_path)
+
+    def retrieve(self, query, source, corpus_dict, top_k=1):
+        if self.index is None:
+            docs = [corpus_dict[int(doc_id)] for doc_id in source]
+            self.build_index(docs, source, save_path=self.index_path)
+
+        query_embedding = self.embed_model.encode(
+            query,
+            prompt="為這個句子生成表示，用以檢索相似的文章: ",
+            convert_to_tensor=True,
+            normalize_embeddings=True,
+        )
+        query_embedding = query_embedding.cpu().numpy().astype('float32').reshape(1, -1)
+        faiss.normalize_L2(query_embedding)
+        _, indices = self.index.search(query_embedding, top_k)
+        return [self.doc_ids[idx] for idx in indices[0]][0]


### PR DESCRIPTION
## Summary
- tune FAISSRetriever with on-disk index caching and HNSW index
- preload category indexes in the main pipeline

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b075b750832285418c23655fcc2c